### PR TITLE
Fix: removes duplicated animal for raccoon

### DIFF
--- a/src/words.rs
+++ b/src/words.rs
@@ -665,7 +665,6 @@ pub(crate) const ANIMALS: &[&str] = &[
     "pony",
     "porcupine",
     "puma",
-    "raccoon",
     "reindeer",
     "rhino",
     "skunk",


### PR DESCRIPTION
This is the reason why we have twice hotspots on the network named raccoon.